### PR TITLE
feature(config) Make global invervals editable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ You may want to connect Prometheus to a Promscale instance. In this case, one ne
 
 Promscale is currently the only available backend. Feel free to open an issue and a pull request to support various backends.
 
+### Prometheus configuration
+
+Global Prometheus configuration can be configured using the following environment variables:
+
+* `PROMETHEUS_GLOBAL_EVALUATION_INTERVAL` (default: `1m`): How frequently to evaluate rules
+* `PROMETHEUS_GLOBAL_SCRAPE_INTERVAL` (default: `1m`): How frequently to scrape targets by default
+
 ### Scrape Configs
 
 Define the environment variable `PROMETHEUS_SCRAPE_CONFIGS` with a JSON containing the equivalent of the YAML configuration for the Prometheus [scrape config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config).

--- a/opt/prometheus.yml.erb
+++ b/opt/prometheus.yml.erb
@@ -1,6 +1,6 @@
 global:
-  scrape_interval:     15s
-  evaluation_interval: 30s
+  scrape_interval:     <%= ENV["PROMETHEUS_GLOBAL_SCRAPE_INTERVAL"] || "1m" %>
+  evaluation_interval: <%= ENV["PROMETHEUS_GLOBAL_EVALUATION_INTERVAL"] || "1m" %>
 
 remote_write:
   - url: "<%= promscale_url %>/write"


### PR DESCRIPTION
And fallback to prometheus defaults

Related to [SRE-380]

Tested on the prometheus staging app with default and custom environment variables.

[SRE-380]: https://scalingo.atlassian.net/browse/SRE-380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ